### PR TITLE
Fix OCSP responses with non successful status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tests/output/
 .DS_Store
 .coverage
 .tox
+.cache/
+*.swp

--- a/ocspbuilder/__init__.py
+++ b/ocspbuilder/__init__.py
@@ -472,8 +472,10 @@ class OCSPResponseBuilder(object):
         """
 
         self.response_status = response_status
-        self.certificate = certificate
-        self.certificate_status = certificate_status
+        if response_status == "successful" or certificate:
+            self.certificate = certificate
+        if response_status == "successful" or certificate_status:
+            self.certificate_status = certificate_status
         self.revocation_date = revocation_date
 
         self._key_hash_algo = 'sha1'

--- a/tests/test_ocsp_response_builder.py
+++ b/tests/test_ocsp_response_builder.py
@@ -188,3 +188,21 @@ class OCSPResponseBuilderTests(unittest.TestCase):
         self.assertEqual('unknown', cert_response['cert_status'].name)
         self.assertGreaterEqual(datetime.now(timezone.utc), cert_response['this_update'].native)
         self.assertGreaterEqual(set(), cert_response.critical_extensions)
+
+    def test_build_error_response(self):
+        """
+        Build a response with error status.
+        """
+        error_statuses = ['malformed_request', 'internal_error',
+                          'try_later', 'sign_required', 'unauthorized']
+
+        for status in error_statuses:
+            builder = OCSPResponseBuilder(status)
+            ocsp_response = builder.build()
+            der_bytes = ocsp_response.dump()
+
+            new_response = asn1crypto.ocsp.OCSPResponse.load(der_bytes)
+            assert dict(new_response.native) == {
+                'response_status': status,
+                'response_bytes': None,
+            }


### PR DESCRIPTION
Responses with non successful status do not need a certificate or a certificate status.

(Right now, this test fails because `None` cannot be parsed as a certificate.)

Also includes a regression test.
